### PR TITLE
Improve connection handling robustness

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -607,7 +607,8 @@ make_option_getter(Local, Global) ->
                             ssl -> false;
                             keyspace -> undefined;
                             name -> undefined;
-                            protocol_version -> ?DEFAULT_PROTOCOL_VERSION
+                            protocol_version -> ?DEFAULT_PROTOCOL_VERSION;
+                            tcp_opts -> []
                         end;
                     GlobalVal -> GlobalVal
                 end;

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -328,7 +328,7 @@ handle_info({preparation_failed, {_Inet, Statement}, Reason}, live,
 handle_info({ tcp_closed, _Socket }, starting, State) ->
     stop_during_startup({error, connection_closed}, State);
 
-handle_info({ tcp_closed, _Socket }, live, State = #client_state{ queries = Queries }) ->
+handle_info({ tcp_closed, _Socket }, _, State = #client_state{ queries = Queries }) ->
     [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
     {stop, connection_closed, State};
 

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -811,12 +811,8 @@ create_socket({Addr, Port}, OptGetter) ->
     Result = case {ssl, OptGetter(ssl)} of
         {ssl, false} ->
             Transport = tcp,
-            case {tcp_opts, OptGetter(tcp_opts)} of
-                {tcp_opts, undefined} ->
-                    gen_tcp:connect(Addr, Port, BaseOpts, 2000);
-                {tcp_opts, TCPOpts} when is_list(TCPOpts) ->
-                    gen_tcp:connect(Addr, Port, BaseOpts ++ TCPOpts, 2000)
-            end;
+            Opts = BaseOpts ++ OptGetter(tcp_opts),
+            gen_tcp:connect(Addr, Port, Opts, 2000);
 
         {ssl = Transport, true} ->
             ssl:connect(Addr, Port, BaseOpts, 2000);

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -149,7 +149,7 @@ normalise_to_atom(KS) when is_atom(KS) -> KS.
 %% ------------------------------------------------------------------
 
 init([Inet, Opts, OptGetter, Key]) ->
-    case create_socket(Inet, Opts) of
+    case create_socket(Inet, OptGetter) of
         {ok, Socket, Transport} ->
             {AuthHandler, AuthArgs} = OptGetter(auth),
             cqerl:put_protocol_version(OptGetter(protocol_version)),
@@ -796,15 +796,15 @@ send_to_db(#client_state{trans=ssl, socket=Socket}, Data) when is_binary(Data) -
 
 
 
-create_socket({Addr, Port}, Opts) ->
+create_socket({Addr, Port}, OptGetter) ->
     BaseOpts = [{active, false}, {mode, binary}],
-    Result = case proplists:lookup(ssl, Opts) of
+    Result = case {ssl, OptGetter(ssl)} of
         {ssl, false} ->
             Transport = tcp,
-            case proplists:lookup(tcp_opts, Opts) of
-                none ->
+            case {tcp_opts, OptGetter(tcp_opts)} of
+                {tcp_opts, undefined} ->
                     gen_tcp:connect(Addr, Port, BaseOpts, 2000);
-                {tcp_opts, TCPOpts} ->
+                {tcp_opts, TCPOpts} when is_list(TCPOpts) ->
                     gen_tcp:connect(Addr, Port, BaseOpts ++ TCPOpts, 2000)
             end;
 

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -339,6 +339,9 @@ handle_info({ ssl_closed, _Socket }, live, State = #client_state{ queries = Quer
     [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
     {stop, connection_closed, State};
 
+handle_info({tcp_error, _Socket, _Reason}, _, State = #client_state{ queries = Queries }) ->
+    [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
+    {stop, connection_closed, State};
 
 handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ socket=Socket, trans=Transport, delayed=Delayed0 }) ->
     Resp = case cqerl_protocol:response_frame(#cqerl_frame{}, << Delayed0/binary, BinaryMsg/binary >>) of

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -325,29 +325,39 @@ handle_info({preparation_failed, {_Inet, Statement}, Reason}, live,
             {next_state, live, State}
     end;
 
-handle_info({ tcp_closed, _Socket }, starting, State) ->
-    stop_during_startup({error, connection_closed}, State);
+handle_info({tcp_closed, _Socket}, starting, State) ->
+    stop_during_startup({error, {connection_closed, normal}}, State);
 
-handle_info({ tcp_closed, _Socket }, _, State = #client_state{ queries = Queries }) ->
+handle_info({tcp_closed, _Socket}, _, State = #client_state{queries = Queries}) ->
     [ case Call of
-          #cql_call{} -> respond_to_user(Call, {error, connection_closed});
+          #cql_call{} -> respond_to_user(Call, {error, {connection_closed, normal}});
+          _ -> ok
+      end || {_, {Call, _}} <- Queries ],
+    {stop, {connection_closed, normal}, State};
+
+handle_info({tcp_error, _Socket, Reason}, _, State = #client_state{queries = Queries}) ->
+    [ case Call of
+          #cql_call{} -> respond_to_user(Call, {error, {connection_closed, Reason}});
+          _ -> ok
+      end || {_, {Call, _}} <- Queries ],
+    {stop, {connection_closed, Reason}, State};
+
+handle_info({ssl_closed, _Socket}, starting, State) ->
+    stop_during_startup({error, {connection_closed, normal}}, State);
+
+handle_info({ssl_closed, _Socket}, _, State = #client_state{queries = Queries}) ->
+    [ case Call of
+          #cql_call{} -> respond_to_user(Call, {error, {connection_closed, normal}});
           _ -> ok
       end || {_, {Call, _}} <- Queries ],
     {stop, connection_closed, State};
 
-handle_info({ ssl_closed, _Socket }, starting, State) ->
-    stop_during_startup({error, connection_closed}, State);
-
-handle_info({ ssl_closed, _Socket }, live, State = #client_state{ queries = Queries }) ->
-    [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
-    {stop, connection_closed, State};
-
-handle_info({tcp_error, _Socket, _Reason}, _, State = #client_state{ queries = Queries }) ->
+handle_info({ssl_error, _Socket, Reason}, _, State = #client_state{queries = Queries}) ->
     [ case Call of
-          #cql_call{} -> respond_to_user(Call, {error, connection_closed});
+          #cql_call{} -> respond_to_user(Call, {error, {connection_closed, Reason}});
           _ -> ok
       end || {_, {Call, _}} <- Queries ],
-    {stop, connection_closed, State};
+    {stop, {connection_closed, Reason}, State};
 
 handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ socket=Socket, trans=Transport, delayed=Delayed0 }) ->
     Resp = case cqerl_protocol:response_frame(#cqerl_frame{}, << Delayed0/binary, BinaryMsg/binary >>) of

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -329,7 +329,10 @@ handle_info({ tcp_closed, _Socket }, starting, State) ->
     stop_during_startup({error, connection_closed}, State);
 
 handle_info({ tcp_closed, _Socket }, _, State = #client_state{ queries = Queries }) ->
-    [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
+    [ case Call of
+          #cql_call{} -> respond_to_user(Call, {error, connection_closed});
+          _ -> ok
+      end || {_, {Call, _}} <- Queries ],
     {stop, connection_closed, State};
 
 handle_info({ ssl_closed, _Socket }, starting, State) ->
@@ -340,7 +343,10 @@ handle_info({ ssl_closed, _Socket }, live, State = #client_state{ queries = Quer
     {stop, connection_closed, State};
 
 handle_info({tcp_error, _Socket, _Reason}, _, State = #client_state{ queries = Queries }) ->
-    [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
+    [ case Call of
+          #cql_call{} -> respond_to_user(Call, {error, connection_closed});
+          _ -> ok
+      end || {_, {Call, _}} <- Queries ],
     {stop, connection_closed, State};
 
 handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ socket=Socket, trans=Transport, delayed=Delayed0 }) ->

--- a/src/cqerl_client_sup.erl
+++ b/src/cqerl_client_sup.erl
@@ -43,7 +43,7 @@ init([key, Key = {Node, _Opts}, FullOpts, OptGetter, ChildCount]) ->
      {
       #{
        strategy => one_for_one,
-       intensity => 5,
+       intensity => ChildCount + 5,
        period => 10
       },
       [


### PR DESCRIPTION
This PR incorporates a number of fixes regarding connection handling:

- Reports connection termination reason
- Handles `{tcp,ssl}_error` as well as normal termination
- Actually passes `tcp_opts` to `gen_tcp:connect/4`
- Solves the connection pool size vs. restart intensity problem which causes spurious interruption even of the connections which are in use