### PR TITLE
Fix error handling

### DIFF
--- a/src/cqerl.app.src
+++ b/src/cqerl.app.src
@@ -2,7 +2,7 @@
              [{description,"CQErl client for Cassandra"},
               {vsn,"1.0.4"},
               {registered,[cqerl,cqerl_sup,cqerl_cache,cqerl_batch_sup]},
-              {applications,[kernel,stdlib,ssl,pooler,re2,semver,snappy,lz4,
+              {applications,[kernel,stdlib,sasl,ssl,pooler,re2,semver,snappy,lz4,
                              uuid]},
               {mod,{cqerl_app,[]}},
               {env,[]}]}.

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -975,7 +975,7 @@ stop_during_startup(Reason, State = #client_state{users = Users}) ->
     % eaddrinuse errors on further attempts (including valid ones) by clients to
     % connect.
     cqerl_app:mode() =:= pooler andalso timer:sleep(200),
-    {stop, normal, State#client_state{socket=undefined}}.
+    {stop, Reason, State#client_state{socket = undefined}}.
 
 
 next_heartbeat_within(#client_state{last_socket_send = LastSocketSend,

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -667,8 +667,8 @@ maybe_signal_busy(State) ->
 
 
 
-append_delayed_segment({X, Y, State}, Delayed) ->
-    {X, Y, State#client_state{delayed=Delayed}}.
+append_delayed_segment({Next, StateName, State}, Delayed) ->
+    {Next, StateName, State#client_state{delayed=Delayed}}.
 
 
 

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -594,7 +594,7 @@ handle_info(heartbeat_check, StateName, State = #client_state{heartbeat_interval
     {next_state, StateName, State1};
 
 handle_info(Info, StateName, State) ->
-    io:format("Received message ~w while in state ~w~n", [Info, StateName]),
+    error_logger:info_msg("Received message ~w while in state ~w~n", [Info, StateName]),
     {next_state, StateName, State}.
 
 

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -143,4 +143,4 @@ do_add_to_cluster(ClusterKey, ClientKeys) ->
 determine_new_clients(ClusterKey, ClientKeys) ->
     Clusters = ets:lookup(cqerl_clusters, ClusterKey),
     AlreadyStarted = sets:from_list([ C#cluster_table.client_key || C <- Clusters ]),
-    sets:from_list( sets:subtract(sets:from_list(ClientKeys), AlreadyStarted) ).
+    sets:to_list( sets:subtract(sets:from_list(ClientKeys), AlreadyStarted) ).

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -106,25 +106,21 @@ load_initial_clusters() ->
             case application:get_env(cqerl, cassandra_nodes, undefined) of
                 undefined -> ok;
                 ClientKeys when is_list(ClientKeys) ->
-                    handle_call({add_to_cluster, ?PRIMARY_CLUSTER, prepare_client_keys(ClientKeys)}, undefined, undefined)
+                    do_add_to_cluster(?PRIMARY_CLUSTER, prepare_client_keys(ClientKeys))
             end;
-
         Clusters when is_list(Clusters) ->
             lists:foreach(fun
                 ({ClusterKey, {ClientKeys, Opts0}}) when is_list(ClientKeys) ->
-                    handle_call({add_to_cluster, ClusterKey, prepare_client_keys(ClientKeys, Opts0)}, undefined, undefined);
-
+                    do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys, Opts0));
                 ({ClusterKey, ClientKeys}) when is_list(ClientKeys) ->
-                    handle_call({add_to_cluster, ClusterKey, prepare_client_keys(ClientKeys)}, undefined, undefined)
+                    do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys))
             end, Clusters);
-
         Clusters ->
             maps:map(fun
                 (ClusterKey, {ClientKeys, Opts0}) when is_list(ClientKeys) ->
-                    handle_call({add_to_cluster, ClusterKey, prepare_client_keys(ClientKeys, Opts0)}, undefined, undefined);
-
+                    do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys, Opts0));
                 (ClusterKey, ClientKeys) when is_list(ClientKeys) ->
-                    handle_call({add_to_cluster, ClusterKey, prepare_client_keys(ClientKeys)}, undefined, undefined)
+                    do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys))
             end, Clusters)
     end.
 

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -107,22 +107,15 @@ load_initial_clusters() ->
     case application:get_env(cqerl, cassandra_clusters, undefined) of
         undefined ->
             case application:get_env(cqerl, cassandra_nodes, undefined) of
-                undefined -> ok;
+                undefined -> [];
                 ClientKeys when is_list(ClientKeys) ->
                     do_add_to_cluster(?PRIMARY_CLUSTER, prepare_client_keys(ClientKeys))
             end;
         Clusters when is_list(Clusters) ->
-            lists:foreach(fun
+            lists:flatmap(fun
                 ({ClusterKey, {ClientKeys, Opts0}}) when is_list(ClientKeys) ->
                     do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys, Opts0));
                 ({ClusterKey, ClientKeys}) when is_list(ClientKeys) ->
-                    do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys))
-            end, Clusters);
-        Clusters ->
-            maps:map(fun
-                (ClusterKey, {ClientKeys, Opts0}) when is_list(ClientKeys) ->
-                    do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys, Opts0));
-                (ClusterKey, ClientKeys) when is_list(ClientKeys) ->
                     do_add_to_cluster(ClusterKey, prepare_client_keys(ClientKeys))
             end, Clusters)
     end.

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -21,6 +21,8 @@
     add_nodes/3
 ]).
 
+-type client_key() :: cqerl_hash:key().
+
 -define(PRIMARY_CLUSTER, '$primary_cluster').
 -define(ADD_NODES_TIMEOUT, case application:get_env(cqerl, add_nodes_timeout) of
     undefined -> 30000;
@@ -35,6 +37,7 @@ end).
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+-spec add_nodes([client_key()]) -> [{ok, any()} | {error, any()}].
 add_nodes(ClientKeys) ->
     gen_server:call(?MODULE, {add_to_cluster, ?PRIMARY_CLUSTER, ClientKeys}, ?ADD_NODES_TIMEOUT).
 

--- a/src/cqerl_protocol.erl
+++ b/src/cqerl_protocol.erl
@@ -548,7 +548,7 @@ response_frame(Response0=#cqerl_frame{compression_type=CompressionType},
     case HasWarnings of
         true ->
             {ok, Warnings, Body2} = ?DATA:decode_string_list(UncompressedBody),
-            io:format("Warning from Cassandra: ~p~n", [Warnings]);
+            error_logger:warning_msg("Warning from Cassandra: ~p~n", [Warnings]);
         false ->
             Body2 = UncompressedBody
     end,


### PR DESCRIPTION
The critical commit for passing errors up the OTP hierarchy is f35e0d45deba4ad8b3f710aadc4a4f13c695f041, whilst 3d8725efac174aa89c66899a44750861f10c70b3 makes the lib use `error_logger`, so that lager in an encapsulating project can pick the messages up. The rest are mostly niceties.