### PR TITLE
Build c deps using port compiler rebar3 plugin - upgrade lz4 and snappy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {deps, [
-        {snappy, {git, "https://github.com/fdmanana/snappy-erlang-nif.git", {ref, "4e3b861"}}},
-        {lz4, {git, "https://github.com/szktty/erlang-lz4.git", {ref, "6bc5efe93bab327788bcde24374f16044b549dd8"}}},
+        {snappy, {git, "https://github.com/fdmanana/snappy-erlang-nif.git", {ref, "e8907ee8e37cfa07d933a070669a88798082c3d7"}}},
+        {lz4, {git, "https://github.com/szktty/erlang-lz4.git", {ref, "e7ccf4fc9a806982055f26772522c3543c89d1b5"}}},
         {semver, {git, "https://github.com/nebularis/semver.git", {ref, "c7d509"}}},
         {uuid, "1.7.2", {pkg, uuid_erl}},
         {pooler, "1.5.3"},


### PR DESCRIPTION
Use rebar3 pc plugin to compile NIFs.
It's _just_ updating lz4 and snappy to the latest versions.

- https://github.com/skunkwerks/snappy-erlang-nif/commit/e8907ee8e37cfa07d933a070669a88798082c3d7
- https://github.com/szktty/erlang-lz4/commit/e7ccf4fc9a806982055f26772522c3543c89d1b5