### PR TITLE
Update deps: re2 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,10 @@
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {deps, [
-        {snappy, {git, "https://github.com/fdmanana/snappy-erlang-nif.git", {ref, "e8907ee8e37cfa07d933a070669a88798082c3d7"}}},
+        {snappy, {git, "https://github.com/skunkwerks/snappy-erlang-nif.git", {ref, "e8907ee8e37cfa07d933a070669a88798082c3d7"}}},
         {lz4, {git, "https://github.com/szktty/erlang-lz4.git", {ref, "e7ccf4fc9a806982055f26772522c3543c89d1b5"}}},
         {semver, {git, "https://github.com/nebularis/semver.git", {ref, "c7d509"}}},
         {uuid, "1.7.2", {pkg, uuid_erl}},
         {pooler, "1.5.3"},
-        {re2, {git, "https://github.com/tuncer/re2.git", {tag, "v1.7.5"}}}
+        {re2, {git, "https://github.com/dukesoferl/re2.git", {tag, "v1.9.5"}}}
 ]}.


### PR DESCRIPTION
This PR updates dependencies:
* re2 to version 1.9.5 - to allow for compilation on ARM
* snappy - project path update