### PR TITLE
Update re2 library to 1.9.7

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
         {semver, {git, "https://github.com/nebularis/semver.git", {ref, "c7d509"}}},
         {uuid, "1.7.2", {pkg, uuid_erl}},
         {pooler, "1.5.3"},
-        {re2, {git, "https://github.com/dukesoferl/re2.git", {tag, "v1.9.5"}}}
+        {re2, {git, "https://github.com/dukesoferl/re2.git", {tag, "v1.9.7"}}}
 ]}.


### PR DESCRIPTION
Tried building a forked version of MongooseIM on an Apple M1 Pro computer which depends on this library and got build errors along the lines of `-m64` flag not being supported, which comes from: https://github.com/dukesoferl/re2/blob/v1.9.5/c_src/build_deps.sh#L70, this was removed in v1.9.6.

This PR will make it so someone with an Apple M1 Pro, or ARM processor (since `-m64` isn't supported on ARM arch as far as I know) can properly build any project using this one as a dependency.